### PR TITLE
Add .tmp to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Godot 4+ specific ignores
 .godot/
 /android/
+.tmp


### PR DESCRIPTION
Godot creates these files temporarily for running a scene and sometimes doesn't clean them up. They shouldn't end up in source control. https://www.reddit.com/r/godot/comments/16akyka/what_are_all_these_tmp_files_alongside_my_main/