### PR TITLE
Tile system

### DIFF
--- a/Scripts/base_tile.gd
+++ b/Scripts/base_tile.gd
@@ -1,11 +1,13 @@
 extends Node3D
-
+class_name BaseTile
 
 @onready var hex_grass_3: Node3D = $hex_grass3
 
 var mesh_instance: MeshInstance3D
 var default_material: Material
 var highlight_material: Material
+
+var pos: Vector2i
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -37,7 +39,7 @@ func setup_materials():
 		push_error("No material found on mesh")
 
 func highlight():
-	print(self, "highlight is called")
+	print(self, "highlight is called at " + str(pos))
 	if mesh_instance and highlight_material:
 		print(self, "do highlight")
 		mesh_instance.set_surface_override_material(0, highlight_material)

--- a/Scripts/base_tile.gd
+++ b/Scripts/base_tile.gd
@@ -7,7 +7,14 @@ var mesh_instance: MeshInstance3D
 var default_material: Material
 var highlight_material: Material
 
-var pos: Vector2i
+## Position 
+var pos: TilePos:
+	get:
+		return TilePos.from_array_pos(array_pos.x, array_pos.y)
+	set(tp):
+		array_pos = tp.to_array_pos()
+var array_pos: Vector2i
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:

--- a/Scripts/tile_pos.gd
+++ b/Scripts/tile_pos.gd
@@ -1,0 +1,50 @@
+extends Object
+class_name TilePos
+## Represents a tile position using cubic/axial coordinates
+##
+## QRS are nice for calculating positions, but are hard to grasp.
+## Consider using [member from_array_pos] to generate TilePos
+##
+## @tutorial(d): https://www.redblobgames.com/grids/hexagons/
+
+var q: int
+var r: int
+var s: int:
+	get:
+		return -q-r
+
+
+## Create a new TilePos using the cubic coordinates
+func _init(q: int, r: int):
+	self.q = q
+	self.r = r
+	self.s = -q-r
+
+
+## Add two positions together
+func add(tp: TilePos):
+	return TilePos.new(q+tp.q, r+tp.r)
+	
+	
+## Add two positions together
+func multiply(i: int):
+	return TilePos.new(q*i, r*i)
+
+
+## Create a TilePos from a given row, col from the TileSpawner array
+static func from_array_pos(col, row) -> TilePos:
+	var new_q = col
+	var new_r = -row - (col + (col&1)) / 2
+	return TilePos.new(new_q, new_r)
+
+
+## Convert this TilePos to array coordinates we use for saving the tiles
+func to_array_pos() -> Vector2i:
+	var col: int = q
+	var row: int = -(r + (q + (q&1)) / 2)
+	return Vector2i(col, row)
+		
+
+## Represent the QRS like a Vector3i	
+func _to_string():
+	return str(to_array_pos())

--- a/Scripts/tile_spawner.gd
+++ b/Scripts/tile_spawner.gd
@@ -14,7 +14,8 @@ func spawn(col, row) -> void:
 			offset = 0
 		for m in row:
 			#Tile Object wird instantiiert
-			var tile = BASE_TILE.instantiate()
+			var tile = BASE_TILE.instantiate() as BaseTile
+			tile.pos = Vector2i(n, m)
 			get_parent().add_child(tile)
 			#Tile position wird festgelegt
 			tile.transform.origin.z = n * 1.8
@@ -30,7 +31,8 @@ func spawn_alternate(row, col) -> void:
 		if n%2 == 0: 
 			offset = 0
 		for m in range(row):
-			var tile = BASE_TILE.instantiate()
+			var tile = BASE_TILE.instantiate() as BaseTile
+			tile.pos = Vector2i(n, m)
 			tile.position = Vector3((m * 2) + offset, 0, n * 1.8)
 			tile.add_to_group("tileGroup")
 			

--- a/Scripts/tile_spawner.gd
+++ b/Scripts/tile_spawner.gd
@@ -1,4 +1,5 @@
 extends Node
+class_name TileSpawner
 
 const BASE_TILE = preload("res://Scenes/base_tile.tscn")
 
@@ -32,13 +33,12 @@ func spawn_alternate(row, col) -> void:
 			offset = 0
 		for m in range(row):
 			var tile = BASE_TILE.instantiate() as BaseTile
-			tile.pos = Vector2i(n, m)
+			tile.array_pos = Vector2i(n, m)
 			tile.position = Vector3((m * 2) + offset, 0, n * 1.8)
 			tile.add_to_group("tileGroup")
 			
 			get_parent().add_child(tile)
 			new_row.append(tile)
-			
 		tiles.append(new_row)
 
 

--- a/Scripts/tile_system.gd
+++ b/Scripts/tile_system.gd
@@ -1,5 +1,10 @@
 extends Node
+class_name TileSystem
+## Interface object to the TileSystem.
+##
+## TileSpawner handles generation and storage of the tiles.
 
+@onready var _spawner = $TileSpawner
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -9,3 +14,11 @@ func _ready() -> void:
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
 	pass
+
+
+## Get the tile at [param pos].
+## Returns null when it can not be found: Out of bounds, not yet initialized etc.
+func get_tile(pos: TilePos) -> BaseTile:
+	var ap: Vector2i = pos.to_array_pos()
+	return _spawner.get_tile(ap.x, ap.y)
+	


### PR DESCRIPTION
Major changes:
 - Save the position of each tile in the tile itself
 - Add a tile position class that enables vector math on hexagonal maps
 - Expose the `get_tile` function of TileSpawner in TileSystem, so other parts of the program don't need to know about TileSpawner
Minor change:
- Give base_tile, tile_system, tile_spawner each a class_name so they can be used for type annotation
e.g. `var tile_system: TileSystem = $TileSystem`

Math is taken from https://www.redblobgames.com/grids/hexagons